### PR TITLE
:not() alternative for menu siblings elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Instead of putting on the border...
 }
 ```
 
+... or, since your menu elements might be siblings, use the tild operator and turn the problem on it's head
+
+```css
+.nav li:first-child ~ li {
+  border-left: 1px solid #666;
+}
+```
+
 It's clean, readable, and easy to understand without the need for hack-y code.
 
 


### PR DESCRIPTION
Even supported under IE8 (You are right.. who cares now ! Almost nobody .. almost.)