### PR TITLE
Use double colons (::) for pseudo elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ html {
   box-sizing: border-box;
 }
 
-*, *:before, *:after {
+*, *::before, *::after {
   box-sizing: inherit;
 }
 ```


### PR DESCRIPTION
Hello, it's recommended by the CSS3 standard to use double colons (::) for pseudo elements. See:
https://developer.mozilla.org/en/docs/Web/CSS/Pseudo-elements