### PR TITLE
to ensure consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ Instead of putting on the border...
 }
 ```
 
-...and then taking it off the last element...
+...and then taking it off the first element...
 
 ```css
 /* remove border */
-.nav li:last-child {
+.nav li:first-child {
   border-right: none;
 }
 ```
@@ -134,7 +134,7 @@ Instead of putting on the border...
 ...use the `:not()` pseudo-class to only apply to the elements you want:
 
 ```css
-.nav li:not(:last-child) {
+.nav li:not(:first-child) {
   border-right: 1px solid #666;
 }
 ```

--- a/translations/zh-CN/README.md
+++ b/translations/zh-CN/README.md
@@ -123,11 +123,11 @@ button {
 }
 ```
 
-为最后一个元素去除边框
+为第一个元素去除边框
 
 ```css
 /* 去掉边框 */
-.nav li:last-child {
+.nav li:first-child {
   border-right: none;
 }
 ```
@@ -135,7 +135,7 @@ button {
 不过不要这么做，使用 `:not()` 伪类来达到同样的效果：
 
 ```css
-.nav li:not(:last-child) {
+.nav li:not(:first-child) {
   border-right: 1px solid #666;
 }
 ```


### PR DESCRIPTION
Regarding point 4, about the ":not()".
your demo is:
```
.nav li:not(:last-child) {
  border-right: 1px solid #666;
}
```
> Sure, you can use .nav li + li or even .nav li:first-child ~ li, but with :not() the intent is very clear and the CSS selector defines the border the way a human would describe it.

but, in fact,  .nav li + li or even .nav li:first-child ~ li, All indicate selectors other than the first element，
Therefore, in order to avoid readers' misunderstanding, you can change the selector in the demo to：
```
.nav li:not(:first-child) {
  border-right: 1px solid #666;
}
```