### PR TITLE
Add note for accessibility regarding empty <a> tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ a[href^="http"]:empty::before {
 
 That's pretty convenient.
 
+**Note:** This tip may not be ideal for accessibility, specifically screen readers. And copy/paste from the browser doesn't work with CSS-generated content. Proceed with caution.
+
 #### [Demo](http://codepen.io/AllThingsSmitty/pen/zBzXRx)
 
 <sup>[back to table of contents](#table-of-contents)</sup>


### PR DESCRIPTION
Same as with comma's in lists, this link is not copyable and screenreaders have a hard time reading this out to a user.